### PR TITLE
Fix buffering issues

### DIFF
--- a/lib/subcontractor/cli.rb
+++ b/lib/subcontractor/cli.rb
@@ -1,7 +1,6 @@
 require 'optparse'
 require 'pty'
 
-# make foreman show logs right away
 $stdout.sync = true
 
 module SafePty
@@ -26,7 +25,6 @@ module Subcontractor
     def run
       options = parse_options(ARGV)
       command = build_command(ARGV.dup, options)
-      puts command
       Dir.chdir(options[:chdir]) if options[:chdir]
       signal = options[:signal] || "TERM"
       SafePty.spawn(command) do |stdin, stdout, pid|


### PR DESCRIPTION
When running apps with subcontractor, the process will buffer the output, which means that you won't see some of your console logs before you Ctrl+C. 

This pull request fixes that by disabling the stdout buffering.
