### PR TITLE
Bundler environment isn't reset for spawned processes

### DIFF
--- a/lib/subcontractor/cli.rb
+++ b/lib/subcontractor/cli.rb
@@ -5,7 +5,16 @@ $stdout.sync = true
 
 module SafePty
   def self.spawn command, &block
+    if Object.const_defined?('Bundler')
+      Bundler.with_clean_env do
+        self.spawn_internal command, &block
+      end
+    else
+      self.spawn_internal command, &block
+    end
+  end
 
+  def self.spawn_internal command, &block
     PTY.spawn(command) do |r,w,p|
       begin
         yield r,w,p


### PR DESCRIPTION
My Procfile has a line like this:

   faye: bundle exec subcontract --rvm 1.9.3 --chdir faye -- bundle exec rackup config.ru -s thin -p $PORT -E production

however it doesn't execute rackup under the correct bundler environment - instead it uses the original environment.  See pull request for proposed fix.

Also, did you really mean to checkin your ".rvmrc" file for this project?
