### PR TITLE
Update rvmrc usage instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,11 @@ another_app: subcontract --rvm ruby-1.8.7-p249@another_app --chdir ../another_ap
 
 Here another_app will be launch from the sibling directory another_app and will use the rvm ruby-1.8.7-p249@another_app. As you can see, the command that we wish to use to launch our application follows the double dashes (--).
 
-You can also allow another_app to use its existing .rvmrc file
+You can also allow another_app to use its existing .rvmrc file. This will load the .rvmrc file out of the current folder once it has been changed to the folder specified by --chdir
 
 ```
 rails: rails s
-another_app: subcontract --rvm "--with-rubies rvmrc" --chdir ../another_app --signal INT -- rails s -p 3001
-```
-
-Newer versions of RVM use a slightly different syntax for referencing the app .rvmrc file.
-
-```
-new_rvm_app: push: subcontract --rvm --with-rubies default-with-rvmrc do --chdir ../push --signal INT -- bundle exec rails server
+another_app: subcontract --rvm . --chdir ../another_app --signal INT -- rails s -p 3001
 ```
 
 You can use specific rbenv version.


### PR DESCRIPTION
Per wayneeseguin/rvm#1729 the current method for using the local .rvmrc is `rvm . do ...`. This allows the subcontractor syntax to look like:

`another_app: subcontract --rvm . --chdir ../another_app --signal INT -- rails s -p 3001`
