### PR TITLE
Accepts --env option to export environment variables to the executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ USAGE: subcontract [options] -- executable
     -c, --choose-env ENV             run in either a specified RBENV, RVM or CHRUBY, whichever is present
     -d, --chdir PATH                 chdir to PATH before starting process
     -s, --signal SIGNAL              signal to send to process to kill it, default TERM
+    -e, --env VAR=value              additional environment variable to be set on executable context
 ```
 
 An example Procfile tells the story
@@ -65,6 +66,12 @@ If you have team members using both rvm and rbenv on a project then use --choose
 
 ```
 mixed_env_manager_app: bundle exec subcontract --choose-env . --chdir ~/mixed_env_manager_app -- bundle exec rails server -p 3001
+```
+
+You can pass multiple environment variables to be passed along to the executable.
+
+```
+rbenv_app: bundle exec subcontract --rbenv 'ree-1.8.7-2012.02' --chdir ~/rbenv_app --env FOO=bar --env BAR=foo -- bundle exec rails server -p 3001
 ```
 
 

--- a/lib/subcontractor/cli.rb
+++ b/lib/subcontractor/cli.rb
@@ -76,6 +76,7 @@ module Subcontractor
 
     def parse_options(argv)
       options = {}
+      options[:env] = []
       parser = OptionParser.new do |opt|
         opt.banner = "USAGE: subcontract [options] -- executable"
         opt.on("-r", "--rvm RVM", "run in a specific RVM") do |rvm|
@@ -95,6 +96,9 @@ module Subcontractor
         end
         opt.on("-s", "--signal SIGNAL", "signal to send to process to kill it, default TERM") do |signal|
           options[:signal] = signal
+        end
+        opt.on("-e", "--env VAR=value", "additional environment variable to be set on executable context") do |env|
+          options[:env] << "env #{env}"
         end
       end
 

--- a/lib/subcontractor/command.rb
+++ b/lib/subcontractor/command.rb
@@ -18,7 +18,7 @@ module Subcontractor
         @parts.unshift("chruby-exec #{_env_specifier(:chruby)} --")
       end
 
-      @parts.join(" ")
+      (@options[:env] + @parts).join(" ")
     end
 
     def _use_command?(command)

--- a/spec/subcontractor/cli_spec.rb
+++ b/spec/subcontractor/cli_spec.rb
@@ -68,5 +68,27 @@ describe Subcontractor::CLI do
         Subcontractor::CLI.new.run
       end
     end
+
+    context "with --env" do
+      it "specifies custom env variable" do
+        ARGV = ["--env", "FOO=bar", "test"]
+        SafePty.should_receive(:spawn).with("env FOO=bar test")
+        Subcontractor::CLI.new.run
+      end
+
+      it "specifies custom env variables if many where passed" do
+        ARGV = ["--env", "FOO=bar", "--env", "BAR=foo", "test"]
+        SafePty.should_receive(:spawn).with("env FOO=bar env BAR=foo test")
+        Subcontractor::CLI.new.run
+      end
+    end
+
+    context "with --env and --rbenv" do
+      it "specifies custom env variables if many where passed" do
+        ARGV = ["--rbenv", "1.9.3", "--env", "FOO=bar", "--env", "BAR=foo", "test"]
+        SafePty.should_receive(:spawn).with("env FOO=bar env BAR=foo env RBENV_VERSION=1.9.3 rbenv exec test")
+        Subcontractor::CLI.new.run
+      end
+    end
   end
 end


### PR DESCRIPTION
This is useful for many cases, but specially to specify `GEM_PATH` so we can use a specific gemset with `rbenv`.